### PR TITLE
New features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pizza_tower_ls_wasm"
-version = "0.1.0"
+version = "0.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/rooms_ids.rs
+++ b/src/rooms_ids.rs
@@ -99,6 +99,38 @@ pub fn get_starting_room<'a>(level: &Level) -> &'a str {
 
 }
 
+pub fn full_game_split_unlock_rooms(current_room: &str) -> bool {
+
+    return [
+        "tower_tutorial10",
+        "entrance_10",
+        "medieval_10",
+        "ruin_11",
+        "dungeon_10",
+        "badland_9",
+        "graveyard_6",
+        "farm_11",
+        "saloon_6",
+        "plage_cavern2",
+        "forest_john",
+        "space_9",
+        "minigolf_8",
+        "street_john",
+        "sewer_8",
+        "industrial_5",
+        "freezer_escape1",
+        "chateau_9",
+        "kidsparty_john",
+        "war_1",
+        "boss_pepperman",
+        "boss_vigilante",
+        "boss_noise",
+        "boss_fakepepkey",
+        "boss_pizzafacefinale",
+    ].contains(&current_room)
+
+}
+
 /**
  * Return true if it receives a room that should trigger a split, usually where the levels end
  */
@@ -111,8 +143,6 @@ pub fn full_game_split_rooms(exited_level: &str) -> bool {
         "ruin_1",
         "dungeon_1" ,
         "badland_1",
-        "badland_1",
-        "rank_room",
         "graveyard_1",
         "farm_2",
         "saloon_1",

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -3,13 +3,24 @@ pub struct Settings {
     #[default = false]
     /// Full Game Mode
     pub full_game: bool,
+
+    #[default = false]
+    /// Save the IGT to LiveSplit's "Game Time"
+    pub save_igt: bool,
+
     #[default = false]
     /// Start on level exit
     pub start_on_exit: bool,
+
     #[default = true]
     /// Split on new rooms
     pub splits_rooms: bool,
+
     #[default = true]
     /// Split on secrets
     pub splits_secrets: bool,
+
+    #[default = false]
+    /// Attempt to find the modded IGT instead of the default IGT
+    pub find_mod_igt: bool,
 }


### PR DESCRIPTION
* Entering and exiting a level won't trigger a full game split anymore.
* Setting to disable saving the IGT to LiveSplit (default: disabled).
* Setting to disable the mod IGT scan, speeding up startup (default: disabled).